### PR TITLE
Add Salesforce-style objects

### DIFF
--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,0 +1,7 @@
+import { accounts } from '@/data/mockData';
+import { NextResponse } from 'next/server';
+
+export function GET(_: Request, { params }: { params: { id: string } }) {
+  const acc = accounts.find(a => a.id === params.id);
+  return acc ? NextResponse.json(acc) : NextResponse.json({ message: 'Not found' }, { status: 404 });
+}

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,0 +1,19 @@
+import { accounts } from '@/data/mockData';
+import { Account } from '@/types/entities';
+import { NextResponse } from 'next/server';
+import { v4 as uuid } from 'uuid';
+
+export function GET() {
+  return NextResponse.json(accounts);
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Partial<Account>;
+  const newAccount: Account = {
+    id: uuid(),
+    name: body.name || 'Account',
+    industry: body.industry,
+  };
+  accounts.push(newAccount);
+  return NextResponse.json(newAccount, { status: 201 });
+}

--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -14,9 +14,12 @@ export async function POST(request: Request) {
   const body = (await request.json()) as Partial<Case>;
   const newCase: Case = {
     id: uuid(),
-    title: body.title ?? 'Untitled',
+    subject: body.subject ?? 'Untitled',
     description: body.description ?? '',
-    status: 'Open',
+    status: 'New',
+    priority: body.priority,
+    accountId: body.accountId,
+    contactId: body.contactId,
     createdAt: new Date().toISOString(),
     assigneeId: body.assigneeId,
     dueDate: body.dueDate,

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,0 +1,7 @@
+import { contacts } from '@/data/mockData';
+import { NextResponse } from 'next/server';
+
+export function GET(_: Request, { params }: { params: { id: string } }) {
+  const contact = contacts.find(c => c.id === params.id);
+  return contact ? NextResponse.json(contact) : NextResponse.json({ message: 'Not found' }, { status: 404 });
+}

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,0 +1,24 @@
+import { contacts } from '@/data/mockData';
+import { Contact } from '@/types/entities';
+import { NextResponse } from 'next/server';
+import { v4 as uuid } from 'uuid';
+
+export function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const accountId = searchParams.get('accountId');
+  const result = accountId ? contacts.filter(c => c.accountId === accountId) : contacts;
+  return NextResponse.json(result);
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Partial<Contact>;
+  const newContact: Contact = {
+    id: uuid(),
+    accountId: body.accountId!,
+    firstName: body.firstName || 'First',
+    lastName: body.lastName || 'Last',
+    email: body.email || '',
+  };
+  contacts.push(newContact);
+  return NextResponse.json(newContact, { status: 201 });
+}

--- a/src/app/case/[id]/page.tsx
+++ b/src/app/case/[id]/page.tsx
@@ -69,7 +69,7 @@ export default function CaseDetail() {
 
   return (
     <div className="space-y-4">
-      <h2 className="text-xl font-semibold">{caseData.title}</h2>
+      <h2 className="text-xl font-semibold">{caseData.subject}</h2>
       <div className="flex items-center gap-2">
         <span>Status:</span>
         <select
@@ -77,8 +77,8 @@ export default function CaseDetail() {
           value={caseData.status}
           onChange={e => updateStatus(e.target.value as CaseStatus)}
         >
-          <option value="Open">Open</option>
-          <option value="In Progress">In Progress</option>
+          <option value="New">New</option>
+          <option value="Working">Working</option>
           <option value="Closed">Closed</option>
         </select>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export default function Home() {
   const [cases, setCases] = useState<Case[]>([]);
-  const [title, setTitle] = useState('');
+  const [subject, setSubject] = useState('');
 
   async function loadCases() {
     const res = await fetch('/api/cases');
@@ -18,9 +18,9 @@ export default function Home() {
     await fetch('/api/cases', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title }),
+      body: JSON.stringify({ subject }),
     });
-    setTitle('');
+    setSubject('');
     loadCases();
   }
 
@@ -29,14 +29,14 @@ export default function Home() {
       <div className="mb-4 flex gap-2">
         <input
           className="border p-2 flex-1"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          placeholder="New case title"
+          value={subject}
+          onChange={e => setSubject(e.target.value)}
+          placeholder="New case subject"
         />
         <button
           className="bg-blue-600 text-white px-4 disabled:opacity-50"
           onClick={createCase}
-          disabled={!title.trim()}
+          disabled={!subject.trim()}
         >
           Add
         </button>
@@ -45,12 +45,12 @@ export default function Home() {
         {cases.map(c => (
           <li key={c.id} className="p-2 border rounded flex justify-between">
             <span>
-              {c.title} -
+              {c.subject} -
               <span
                 className={
                   c.status === 'Closed'
                     ? 'text-gray-600'
-                    : c.status === 'In Progress'
+                    : c.status === 'Working'
                     ? 'text-yellow-600'
                     : 'text-green-600'
                 }

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,16 +1,41 @@
-import { Case, Comment, Document, Person, Task } from '@/types/entities';
+import {
+  Account,
+  Case,
+  Comment,
+  Contact,
+  Document,
+  Person,
+  Task,
+} from '@/types/entities';
 
 export const persons: Person[] = [
   { id: 'u1', name: 'Alice', email: 'alice@example.com', role: 'Manager' },
   { id: 'u2', name: 'Bob', email: 'bob@example.com', role: 'Agent' },
 ];
 
+export const accounts: Account[] = [
+  { id: 'a1', name: 'Acme Corp', industry: 'Manufacturing' },
+];
+
+export const contacts: Contact[] = [
+  {
+    id: 'ct1',
+    accountId: 'a1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane.doe@acme.com',
+  },
+];
+
 export const cases: Case[] = [
   {
     id: 'c1',
-    title: 'First Case',
+    subject: 'First Case',
     description: 'Example case',
-    status: 'Open',
+    status: 'New',
+    priority: 'Medium',
+    accountId: 'a1',
+    contactId: 'ct1',
     assigneeId: 'u2',
     createdAt: new Date().toISOString(),
     dueDate: new Date(Date.now() + 86400000).toISOString(),

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -1,10 +1,26 @@
-export type CaseStatus = 'Open' | 'In Progress' | 'Closed';
+export type CaseStatus = 'New' | 'Working' | 'Closed';
+
+export type CasePriority = 'Low' | 'Medium' | 'High';
 
 export interface Person {
   id: string;
   name: string;
   email: string;
   role: string;
+}
+
+export interface Account {
+  id: string;
+  name: string;
+  industry?: string;
+}
+
+export interface Contact {
+  id: string;
+  accountId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
 }
 
 export interface Task {
@@ -32,9 +48,12 @@ export interface Comment {
 
 export interface Case {
   id: string;
-  title: string;
+  subject: string;
   description: string;
   status: CaseStatus;
+  priority?: CasePriority;
+  accountId?: string;
+  contactId?: string;
   assigneeId?: string;
   createdAt: string;
   dueDate?: string;


### PR DESCRIPTION
## Summary
- define Account, Contact, and new Case interfaces
- expand mock data with accounts and contacts
- add API endpoints for accounts and contacts
- update case APIs and UI to use `subject` and new statuses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d0fb953c08331b867142884ff1f43