### PR TITLE
Add basic CRUD APIs with pagination

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -6,7 +6,11 @@ import { v4 as uuid } from 'uuid';
 export function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const status = searchParams.get('status');
-  const result = status ? cases.filter(c => c.status === status) : cases;
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '10', 10);
+  let result = status ? cases.filter(c => c.status === status) : cases;
+  const start = (page - 1) * pageSize;
+  result = result.slice(start, start + pageSize);
   return NextResponse.json(result);
 }
 

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -6,7 +6,11 @@ import { v4 as uuid } from 'uuid';
 export function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const caseId = searchParams.get('caseId');
-  const result = caseId ? comments.filter(c => c.caseId === caseId) : comments;
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '10', 10);
+  let result = caseId ? comments.filter(c => c.caseId === caseId) : comments;
+  const start = (page - 1) * pageSize;
+  result = result.slice(start, start + pageSize);
   return NextResponse.json(result);
 }
 

--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,22 +1,22 @@
-import { comments } from '@/data/mockData';
+import { documents } from '@/data/mockData';
 import { NextResponse } from 'next/server';
 
 export function GET(_: Request, { params }: { params: { id: string } }) {
-  const c = comments.find(cm => cm.id === params.id);
-  return c ? NextResponse.json(c) : NextResponse.json({ message: 'Not found' }, { status: 404 });
+  const doc = documents.find(d => d.id === params.id);
+  return doc ? NextResponse.json(doc) : NextResponse.json({ message: 'Not found' }, { status: 404 });
 }
 
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
-  const idx = comments.findIndex(cm => cm.id === params.id);
+  const idx = documents.findIndex(d => d.id === params.id);
   if (idx === -1) return NextResponse.json({ message: 'Not found' }, { status: 404 });
   const updates = await request.json();
-  comments[idx] = { ...comments[idx], ...updates };
-  return NextResponse.json(comments[idx]);
+  documents[idx] = { ...documents[idx], ...updates };
+  return NextResponse.json(documents[idx]);
 }
 
 export function DELETE(_: Request, { params }: { params: { id: string } }) {
-  const idx = comments.findIndex(cm => cm.id === params.id);
+  const idx = documents.findIndex(d => d.id === params.id);
   if (idx === -1) return NextResponse.json({ message: 'Not found' }, { status: 404 });
-  const removed = comments.splice(idx, 1);
+  const removed = documents.splice(idx, 1);
   return NextResponse.json(removed[0]);
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -6,7 +6,11 @@ import { v4 as uuid } from 'uuid';
 export function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const caseId = searchParams.get('caseId');
-  const result = caseId ? tasks.filter(t => t.caseId === caseId) : tasks;
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const pageSize = parseInt(searchParams.get('pageSize') || '10', 10);
+  let result = caseId ? tasks.filter(t => t.caseId === caseId) : tasks;
+  const start = (page - 1) * pageSize;
+  result = result.slice(start, start + pageSize);
   return NextResponse.json(result);
 }
 

--- a/test/comments.test.ts
+++ b/test/comments.test.ts
@@ -1,0 +1,24 @@
+import { POST } from '../src/app/api/comments/route';
+import { PUT } from '../src/app/api/comments/[id]/route';
+
+it('updates a comment', async () => {
+  const createRes = await POST(
+    new Request('http://test/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caseId: 'c1', authorId: 'u1', message: 'hi' }),
+    }),
+  );
+  const created = await createRes.json();
+  const updateRes = await PUT(
+    new Request(`http://test/api/comments/${created.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'updated' }),
+    }),
+    { params: { id: created.id } },
+  );
+  const updated = await updateRes.json();
+  expect(updated.message).toBe('updated');
+});
+

--- a/test/documents.test.ts
+++ b/test/documents.test.ts
@@ -1,0 +1,30 @@
+import { POST } from '../src/app/api/documents/route';
+import { PUT, DELETE } from '../src/app/api/documents/[id]/route';
+
+it('creates and deletes a document', async () => {
+  const createRes = await POST(
+    new Request('http://test/api/documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caseId: 'c1', name: 'Doc', url: '#' }),
+    }),
+  );
+  const created = await createRes.json();
+  const updateRes = await PUT(
+    new Request(`http://test/api/documents/${created.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated' }),
+    }),
+    { params: { id: created.id } },
+  );
+  const updated = await updateRes.json();
+  expect(updated.name).toBe('Updated');
+  const delRes = await DELETE(
+    new Request(`http://test/api/documents/${created.id}`, { method: 'DELETE' }),
+    { params: { id: created.id } },
+  );
+  const removed = await delRes.json();
+  expect(removed.id).toBe(created.id);
+});
+

--- a/test/pagination.test.ts
+++ b/test/pagination.test.ts
@@ -1,0 +1,23 @@
+import { GET, POST } from '../src/app/api/cases/route';
+
+it('paginates cases', async () => {
+  await POST(
+    new Request('http://test/api/cases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: 'Case A' }),
+    }),
+  );
+  await POST(
+    new Request('http://test/api/cases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: 'Case B' }),
+    }),
+  );
+
+  const res = await GET(new Request('http://test/api/cases?page=1&pageSize=1'));
+  const data = await res.json();
+  expect(data.length).toBe(1);
+});
+


### PR DESCRIPTION
## Summary
- implement pagination support for cases, tasks, and comments API routes
- expose PUT handler for comments
- add document item API with GET/PUT/DELETE handlers
- include unit tests for new routes and pagination

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d13ec08f4833196c8ab0182655946